### PR TITLE
Enable use with v8 of webdriverIO

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "kagekiri": "^1.4.1"
   },
   "peerDependencies": {
-    "webdriverio": ">=6.0.0 <8.0.0"
+    "webdriverio": ">=6.0.0 <9.0.0"
   },
   "devDependencies": {
     "@wdio/cli": "^7.19.2",


### PR DESCRIPTION
Currently this peerDependency setting blocks the use of wdio-shadowdom-service with webdriverIO v8. I have tested this change on my test suites with wdio v8 and found no issues.